### PR TITLE
Fix debug function (** argument convention)

### DIFF
--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -77,7 +77,7 @@ def debug(*args, **kwargs):
     Same as print, but prints to ``stderr``
     (which is not intercepted by Pandoc).
     """
-    print(*args, **kwargs, file=sys.stderr)
+    print(file=sys.stderr,*args, **kwargs)
 
 
 def convert_text(text, input_format='markdown', output_format='json',


### PR DESCRIPTION
Don't know why the previous notation produces a SyntaxError on my Python version (3.4.3 win32).