### PR TITLE
Use json.dumps instead of dump for Py2 compatibility

### DIFF
--- a/panflute/io.py
+++ b/panflute/io.py
@@ -99,13 +99,12 @@ def dump(doc, output_stream=None):
 
     json_serializer = lambda elem: elem.to_json()
 
-    json.dump(
+    output_stream.write(json.dumps(
         obj=doc,
-        fp=output_stream,
         default=json_serializer,  # Serializer
         separators=(',', ':'),  # Compact separators, like Pandoc
         ensure_ascii=False  # For Pandoc compat
-    )
+    ))
 
 
 def toJSONFilters(actions,


### PR DESCRIPTION
This change is backwards compatible with Py2 and Py3. `json.dump` apparently has bugs in Py2 when dealing with unicode, whereas `json.dumps` works correctly in both Python2 and Python3. See [StackOverflow](http://stackoverflow.com/a/34574105/5451769) for reference.