### PR TITLE
Travis CI: build against pandoc 1.17.2, 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+# os: linux and sudo: false is assumed, which means it is using container-based Ubuntu 12.04
 language: python
+# build matrix: different python and pandoc versions
 python:
   - "3.3"
   - "3.4"
@@ -7,15 +9,18 @@ python:
   - "3.6-dev" # 3.6 development branch
   - "nightly" # currently points to 3.7-dev
   - "pypy3"
+env:
+  - pandocVersion=1.17.2
+  - pandocVersion=1.18
 # command to install dependencies
 #install: "pip install -r requirements.txt"
-addons:
-  apt:
-    packages:
-      pandoc
 before_install:
-  - pip install shutilwhich
-  - pip install pandocfilters
+  - pip install -U shutilwhich
+                   pandocfilters
+  - wget https://github.com/jgm/pandoc/releases/download/$pandocVersion/pandoc-$pandocVersion-1-amd64.deb &&
+    sudo dpkg -i pandoc-$pandocVersion-1-amd64.deb
 install: "python setup.py install"
 # command to run tests
 script: py.test
+cache:
+  - pip


### PR DESCRIPTION
Fix issue #16.

The reason travis was failing is because travis' container-based distro is Ubuntu 12.04, so it actually is using `pandoc_1.9.1.1-1_amd64.deb`!

However, the container-based VM is still the best option because of boot time (a few seconds!). Here I use wget to install the binary from GitHub directly.

The build is now also build against 2 different versions of pandoc. You can add as many as you want, but note that the current build time of this 7X2 builds is about 4 minutes.

I guess the most important versions of pandoc to check would be these 2 since the JSON output has recently been changed in 1.18, right?