### PR TITLE
Stop depending on the order of the JSON input

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.3',
+    version='1.4.4',
 
     description='Pythonic Pandoc filters',
     long_description=long_description,


### PR DESCRIPTION
We no longer depend on "t" being before "c" (or anything like that).
This is a more general fix that the one applied by 2686e76

EG: we expect to see {"t":"Str","c":"x"}
But that's not a guarantee and could change in the future

This should make panflute *a bit* slower