### PR TITLE
setup travis to always deploy on PyPI (#22)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # os: linux and sudo: false is assumed, which means it is using container-based Ubuntu 12.04
 language: python
+cache: pip
 # build matrix: different python and pandoc versions
 python:
   - "3.3"
@@ -12,18 +13,6 @@ python:
 env:
   - pandocVersion=1.17.2
   - pandocVersion=1.18
-# command to install dependencies
-#install: "pip install -r requirements.txt"
-before_install:
-  - pip install -U shutilwhich
-                   pandocfilters
-  - wget https://github.com/jgm/pandoc/releases/download/$pandocVersion/pandoc-$pandocVersion-1-amd64.deb &&
-    sudo dpkg -i pandoc-$pandocVersion-1-amd64.deb
-install: "python setup.py install"
-# command to run tests
-script: py.test
-cache:
-  - pip
 matrix:
   allow_failures:
     - python: "3.5-dev"
@@ -31,3 +20,19 @@ matrix:
     - python: "nightly"
     - python: "pypy3"
   fast_finish: true
+# command to install dependencies
+before_install:
+  - wget https://github.com/jgm/pandoc/releases/download/$pandocVersion/pandoc-$pandocVersion-1-amd64.deb &&
+    sudo dpkg -i pandoc-$pandocVersion-1-amd64.deb
+  - pip install -e .[test]
+install: "python setup.py install"
+# command to run tests
+script: py.test
+deploy:
+  provider: pypi
+  user: sergiocorreia
+  password: $pypi_password
+  skip_cleanup: true
+  on:
+    python: "3.5"
+    condition: $pandocVersion = 1.18-1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 shutilwhich
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 shutilwhich
-pandocfilters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+shutilwhich
+pandocfilters

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,10 @@ setup(
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    #extras_require={
+    extras_require={
     #    'dev': ['check-manifest'],
-    #    'test': ['coverage'],
-    #},
+        'test': ['shutilwhich', 'pandocfilters'],
+    },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pyyaml'],
+    install_requires=['shutilwhich', 'pyyaml'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Since you use Windows and use GitHub Desktop, I figure it would be easier for you to let Travis deploy to PyPI *everytime*. Only when the version is bumped, it will go through. So effectively Travis will auto deploy to PyPI whenever you change the version and commit. (If the version isn't changed, it won't go through. There's an error but since it is in the deploy stage, the error won't result in a fail build.)

What's done:

- setup Travis' deploy to PyPI
- I also rearrange the `.travis.yml` into a more logical order.
- `setup.py` and `requirements.txt` are setup; in particular, travis can now install the dependency by `pip install -e .[test]`

# Setting up Travis' Environmental Variables

Because I don't have your PyPI password, you need to go into <https://travis-ci.org/sergiocorreia/panflute>:

```
More Options -> Settings -> Environment Variables

Name: pypi_password
Value: <your PyPI password
Display value in build log: OFF
```

This last setting is very important. If it is `OFF` it will be secured and any others won't be able to see/use it.

>By default, the value of these new environment variables is hidden from the export line in the logs. This corresponds to the behavior of encrypted variables in your .travis.yml.
>
>Similarly, we do not provide these values to untrusted builds, triggered by pull requests from another repository.
>
>As an alternative to the web interface, you can also use the CLI’s env command.

Reference: [Environment Variables - Travis CI](https://docs.travis-ci.com/user/environment-variables/)

Since I don't have your password I can't test the whole process. But I have used it in my own repo so it should be fine. I suggest you to test it once and verify it goes through to PyPI though.