### PR TITLE
travis: deploy on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,6 @@ deploy:
   password: $pypi_password
   skip_cleanup: true
   on:
+    branch: master
     python: "3.5"
     condition: $pandocVersion = latest


### PR DESCRIPTION
Currently, if there's some other branch that incremented the version so that it is bigger than the one in PyPI, it will "accidentally" deployed that branch to PyPI.