### PR TITLE
Py2 refactoring: minimize the footprint of py2 code

### DIFF
--- a/panflute/base.py
+++ b/panflute/base.py
@@ -15,7 +15,7 @@ from .utils import check_type, encode_dict  # check_group
 
 import sys
 py2 = sys.version_info[0] == 2
-if not py2: basestring = str
+if py2: str = basestring
 
 
 # ---------------------------
@@ -84,8 +84,8 @@ class Element(object):
     # ---------------------------
 
     def _set_ica(self, identifier, classes, attributes):
-        self.identifier = check_type(identifier, basestring)
-        self.classes = [check_type(cl, basestring) for cl in classes]
+        self.identifier = check_type(identifier, str)
+        self.classes = [check_type(cl, str) for cl in classes]
         self.attributes = OrderedDict(attributes)
 
     def _ica_to_json(self):

--- a/panflute/containers.py
+++ b/panflute/containers.py
@@ -12,7 +12,7 @@ from .utils import check_type, encode_dict  # check_group
 
 import sys
 py2 = sys.version_info[0] == 2
-if not py2: basestring = str
+if py2: str = basestring
 
 
 # ---------------------------
@@ -147,7 +147,7 @@ class DictContainer(MutableMapping):
 # ---------------------------
 
 def attach(element, parent, location):
-    if not isinstance(element, (int, basestring, bool)):
+    if not isinstance(element, (int, str, bool)):
         element.parent = parent
         element.location = location
     else:
@@ -156,7 +156,7 @@ def attach(element, parent, location):
 
 
 def to_json_wrapper(e):
-    if isinstance(e, basestring):
+    if isinstance(e, str):
         return e
     elif isinstance(e, bool):
         return encode_dict('MetaBool', e)

--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -10,7 +10,7 @@ from .base import Element, Block, Inline, MetaValue
 
 import sys
 py2 = sys.version_info[0] == 2
-if not py2: basestring = str
+if py2: str = basestring
 
 
 # ---------------------------
@@ -505,7 +505,7 @@ class Citation(Element):
 
     def __init__(self, id, mode='NormalCitation', prefix='', suffix='',
                  hash=0, note_num=0):
-        self.id = check_type(id, basestring)
+        self.id = check_type(id, str)
         self.mode = check_group(mode, CITATION_MODE)
         self.hash = check_type(hash, int)
         self.note_num = check_type(note_num, int)
@@ -582,8 +582,8 @@ class Link(Inline):
                  identifier='', classes=[], attributes={}):
         self._set_content(args, Inline)
         self._set_ica(identifier, classes, attributes)
-        self.url = check_type(url, basestring)
-        self.title = check_type(title, basestring)
+        self.url = check_type(url, str)
+        self.title = check_type(title, str)
 
     def _slots_to_json(self):
         ut = [self.url, self.title]
@@ -617,8 +617,8 @@ class Image(Inline):
                  identifier='', classes=[], attributes={}):
         self._set_content(args, Inline)
         self._set_ica(identifier, classes, attributes)
-        self.url = check_type(url, basestring)
-        self.title = check_type(title, basestring)
+        self.url = check_type(url, str)
+        self.title = check_type(title, str)
 
     def _slots_to_json(self):
         ut = [self.url, self.title]
@@ -641,7 +641,7 @@ class Str(Inline):
     __slots__ = ['text']
 
     def __init__(self, text):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
 
     def __repr__(self):
         return 'Str({})'.format(self.text)
@@ -668,7 +668,7 @@ class CodeBlock(Block):
     __slots__ = ['text', 'identifier', 'classes', 'attributes']
 
     def __init__(self, text, identifier='', classes=[], attributes={}):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
         self._set_ica(identifier, classes, attributes)
 
     def _slots_to_json(self):
@@ -689,7 +689,7 @@ class RawBlock(Block):
     __slots__ = ['text', 'format']
 
     def __init__(self, text, format='html'):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
         self.format = check_group(format, RAW_FORMATS)
 
     def _slots_to_json(self):
@@ -714,7 +714,7 @@ class Code(Inline):
     __slots__ = ['text', 'identifier', 'classes', 'attributes']
 
     def __init__(self, text, identifier='', classes=[], attributes={}):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
         self._set_ica(identifier, classes, attributes)
 
     def _slots_to_json(self):
@@ -735,7 +735,7 @@ class Math(Inline):
     __slots__ = ['text', 'format']
 
     def __init__(self, text, format='DisplayMath'):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
         self.format = check_group(format, MATH_FORMATS)
 
     def _slots_to_json(self):
@@ -760,7 +760,7 @@ class RawInline(Inline):
     __slots__ = ['text', 'format']
 
     def __init__(self, text, format='html'):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
         self.format = check_group(format, RAW_FORMATS)
 
     def _slots_to_json(self):
@@ -1259,7 +1259,7 @@ class MetaString(MetaValue):
     __slots__ = ['text']
 
     def __init__(self, text):
-        self.text = check_type(text, basestring)
+        self.text = check_type(text, str)
 
     def __repr__(self):
         return 'MetaString({})'.format(self.text)

--- a/panflute/io.py
+++ b/panflute/io.py
@@ -49,10 +49,7 @@ def load(input_stream=None):
     """
 
     if input_stream is None:
-        if not py2:
-            input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-        else:
-            input_stream = io.open(sys.stdin.fileno())
+        input_stream = io.open(sys.stdin.fileno()) if py2 else io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
 
     # Load JSON and validate it
     doc = json.load(input_stream, object_pairs_hook=from_json)
@@ -128,10 +125,7 @@ def dump(doc, output_stream=None):
 
     assert type(doc) == Doc, "panflute.dump needs input of type panflute.Doc"
     if output_stream is None:
-        if not py2:
-            sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
-        else:
-            sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
+        sys.stdout = codecs.getwriter("utf-8")(sys.stdout) if py2 else codecs.getwriter("utf-8")(sys.stdout.detach())
         output_stream = sys.stdout
 
     # Switch to legacy JSON output; eg: {'t': 'Space', 'c': []}

--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -25,7 +25,7 @@ from functools import partial
 
 
 py2 = sys.version_info[0] == 2
-if not py2: basestring = str
+if py2: str = basestring
 
 
 # ---------------------------
@@ -234,7 +234,7 @@ def _get_metadata(self, key='', default=None, builtin=True):
     """
 
     # Retrieve metadata
-    assert isinstance(key, basestring)
+    assert isinstance(key, str)
     meta = self.metadata
 
     # Retrieve specific key
@@ -281,7 +281,7 @@ def shell(args, wait=True, msg=None):
     """
 
     # Fix Windows error if passed a string
-    if isinstance(args, basestring):
+    if isinstance(args, str):
         args = shlex.split(args, posix=(os.name != "nt"))
         args = [arg.replace('/', '\\') for arg in args]
 


### PR DESCRIPTION
After this commit, a search on the keyword "py2" will find the lines that matter to py2 only. It will be easier to cleanup when py2 support is dropped.