### PR TITLE
README.rst: create by pandoc rather than pypandoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ script:
   # running all available .md files through panflute
   - find . -iname '*.md' -print0 | xargs -0 -i -n1 -P4 bash -c 'pandoc -t native -F panflute -o $0.native $0' {}
 before_deploy:
+  # create README.rst for PyPI README
+  - pandoc -f markdown+autolink_bare_uris-fancy_lists-implicit_header_references -M date="`date "+%B %e, %Y"`" --toc --normalize -S -s -o README.rst README.md
+  # test if the rst output is valid
+  - rst2html.py README.rst > README.html
   # build unpasteurized python3 wheel
   - python3 setup.py bdist_wheel
   # pasteurize except setup.py & panflute/version.py

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
 try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError):
+    with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+        long_description = f.read()
+except (IOError):
     with open(path.join(here, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()
 
@@ -104,7 +104,7 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
     #    'dev': ['check-manifest'],
-        'test': ['pandocfilters', 'pypandoc', 'configparser', 'pytest-cov', 'future'],
+        'test': ['pandocfilters', 'configparser', 'pytest-cov', 'future'],
     },
 
     # If there are data files included in your packages that need to be

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 pandocfilters
-pypandoc
 configparser
 pytest-cov
 future


### PR DESCRIPTION
1. travis can test the validity of the README.rst.
    - It is for PyPI’s README, since an invalid rst will be shown as plain text over PyPI.
    - a failure on rst2html conversion will *not* fail the whole build. But it will be useful to check for errors in Travis when one see the PyPI's README is plaintext.
2. It also removes the extra dep on pypandoc