### PR TITLE
Add missing raw block format.

### DIFF
--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -681,7 +681,7 @@ class RawBlock(Block):
 
     :param text: a string of raw text with another underlying format
     :type text: :class:`str`
-    :param format: Format of the raw text ('html', 'tex' or 'latex')
+    :param format: Format of the raw text ('html', 'tex', 'latex' or 'context')
     :type format: ``str``
     :Base: :class:`Block`
      """
@@ -752,7 +752,7 @@ class RawInline(Inline):
 
     :param text: a string of raw text with another underlying format
     :type text: :class:`str`
-    :param format: Format of the raw text ('html', 'tex' or 'latex')
+    :param format: Format of the raw text ('html', 'tex', 'latex' or 'context')
     :type format: ``str``
     :Base: :class:`Inline`
      """
@@ -1310,7 +1310,7 @@ CITATION_MODE = {'AuthorInText', 'SuppressAuthor', 'NormalCitation'}
 
 MATH_FORMATS = {'DisplayMath', 'InlineMath'}
 
-RAW_FORMATS = {'html', 'tex', 'latex'}
+RAW_FORMATS = {'html', 'tex', 'latex', 'context'}
 
 SPECIAL_ELEMENTS = LIST_NUMBER_STYLES | LIST_NUMBER_DELIMITERS | \
     MATH_FORMATS | TABLE_ALIGNMENT | QUOTE_TYPES | CITATION_MODE


### PR DESCRIPTION
Current versions of Pandoc have one more block format in addition to 'tex', 'html' and 'latex' -- namely, 'context'. If this isn't handled, it becomes impossible to use raw blocks with ConTeXt output.

See https://github.com/jgm/pandoc/blob/master/src/Text/Pandoc/Writers/ConTeXt.hs#L178