### PR TITLE
Fix IndexError on Table header if value is empty TableRow(ListContainer())

### DIFF
--- a/panflute/base.py
+++ b/panflute/base.py
@@ -270,7 +270,7 @@ class Element(object):
                 ans = [(k, v.walk(action, doc)) for k, v in obj.items()]
                 ans = [(k, v) for k, v in ans if v != []]
             elif obj is None:
-                pass  # Empty table headers or captions
+                ans = None # Empty table headers or captions
             else:
                 raise TypeError(type(obj))
             setattr(self, child, ans)

--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1085,7 +1085,7 @@ class Table(Block):
 
     @header.setter
     def header(self, value):
-        if (not value or value is None or not value.content):
+        if (not value or value is None or (isinstance(value, TableRow) and not value.content)):
             self._header = None
             return
 

--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1085,7 +1085,7 @@ class Table(Block):
 
     @header.setter
     def header(self, value):
-        if (not value or value is None):
+        if (not value or value is None or not value.content):
             self._header = None
             return
 


### PR DESCRIPTION
I noticed bug similar to #15, but in my case the content of header was empty ListContainer.

I convert HTML to custom lua writer using panflute filter.
If source html has table without headers (table>tbody>tr>...), panflute will produce for header TableRow with empty ListContainter. That triggers IndexError.

The change in base.py was necessary as not defined `ans` used in following `setattr(self, child, ans)`.