### PR TITLE
Formats for RawBlocks

### DIFF
--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1311,7 +1311,7 @@ CITATION_MODE = {'AuthorInText', 'SuppressAuthor', 'NormalCitation'}
 MATH_FORMATS = {'DisplayMath', 'InlineMath'}
 
 RAW_FORMATS = {'html', 'tex', 'latex', 'context', 'rtf', 'opendocument',
-               'noteref', 'openxml'}
+               'noteref', 'openxml', 'icml'}
 
 SPECIAL_ELEMENTS = LIST_NUMBER_STYLES | LIST_NUMBER_DELIMITERS | \
     MATH_FORMATS | TABLE_ALIGNMENT | QUOTE_TYPES | CITATION_MODE


### PR DESCRIPTION
`icml` is a valid format for `RawBlock`s (there may be more of them, but I couldn't find a list).