### PR TITLE
fix panflute example comment.py

### DIFF
--- a/examples/panflute/comments.py
+++ b/examples/panflute/comments.py
@@ -14,7 +14,7 @@ def prepare(doc):
     doc.ignore = False
 
 def comment(el, doc):
-    is_relevant = (type(el) == pf.RawBlock) and (doc.format == 'html')
+    is_relevant = (type(el) == pf.RawBlock) and (el.format == 'html')
     if is_relevant and re.search("<!-- BEGIN COMMENT -->", el.text):
         doc.ignore = True
     if doc.ignore:


### PR DESCRIPTION
I tried [comment.py](https://github.com/sergiocorreia/panflute/blob/master/examples/panflute/comments.py) to practice panflute, but it did not seem to work.
After reading API, I think the `format` attribute of `el` instead of that of `doc` should be matched to "html". The change works for me.

--
This is my first pull request. I read through the contributing guidelines but did not find rules about examples. Apologize if I disturb.