### PR TITLE
Convert more builtins to MetaValues

### DIFF
--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1483,10 +1483,12 @@ def builtin2meta(val):
         return MetaBool(val)
     elif isinstance(val, (float, int)):
         return MetaString(str(val))
+    elif isinstance(val, str):
+        return MetaString(val)
     elif isinstance(val, list):
-        return MetaList(*val)
+        return MetaList(*[builtin2meta(x) for x in val])
     elif isinstance(val, dict):
-        return MetaMap(*val.items())
+        return MetaMap(*[(k, builtin2meta(v)) for k, v in val.items()])
     elif isinstance(val, Block):
         return MetaBlocks(val)
     elif isinstance(val, Inline):


### PR DESCRIPTION
This commit allows `builtin2meta` to convert `str` to `MetaSting` as
well as recursively converting `list`s and `dict`s.  The original
implementation handled conversion of native `float`, `bool`, and `int`
variables, but did not consider `str`.  On the container side, `list`
and `dict` variables simply passed the item through to `MetaList` and
`MetaMap` respectively.  This tacit assumed the contents was already a
`MetaValue` meaning constructs such as

    doc.metadata["references"] = doc.get_metadata("references")

would fail with a `TypeError`.