### PR TITLE
Update elements.py

### DIFF
--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1311,7 +1311,7 @@ CITATION_MODE = {'AuthorInText', 'SuppressAuthor', 'NormalCitation'}
 MATH_FORMATS = {'DisplayMath', 'InlineMath'}
 
 RAW_FORMATS = {'html', 'tex', 'latex', 'context', 'rtf', 'opendocument',
-               'noteref', 'openxml', 'icml'}
+               'noteref', 'openxml', 'icml', 'markdown'}
 
 SPECIAL_ELEMENTS = LIST_NUMBER_STYLES | LIST_NUMBER_DELIMITERS | \
     MATH_FORMATS | TABLE_ALIGNMENT | QUOTE_TYPES | CITATION_MODE


### PR DESCRIPTION
`panflute.RawBlock` can accept 'markdown' as format.

I searched jgm/pandoc and find a close example in <https://github.com/jgm/pandoc/blob/449910bf407521e04222ee9c64da7c8a253af1dd/src/Text/Pandoc/Shared.hs#L598>.

I think in principle any accepted pandoc formats are valid here. I think I read that somewhere in pandoc-discuss and I'm not 100% certain so this PR only include 'markdown'.