### PR TITLE
Add support for slice assignment to ListContainer

### DIFF
--- a/panflute/containers.py
+++ b/panflute/containers.py
@@ -67,7 +67,10 @@ class ListContainer(MutableSequence):
         del self.list[i]
 
     def __setitem__(self, i, v):
-        v = check_type(v, self.oktypes)
+        if isinstance(i, slice):
+            v = (check_type(x, self.oktypes) for x in v)
+        else:
+            v = check_type(v, self.oktypes)
         self.list[i] = v
 
     def insert(self, i, v):


### PR DESCRIPTION
Modifies `ListContainer.__setitem__` so that it will recognize and properly handle slice assignments.

Python's language reference [isn't quite clear](https://docs.python.org/3/reference/simple_stmts.html#assignment-statements) on what `__setitem__` is supposed to receive during a slice assignment, but the behavior assumed here (receiving a `slice` object as the index and the value unchanged) seems to be standard.