### PR TITLE
Add missing pip dependency for shutilwhich

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 click
+shutilwhich


### PR DESCRIPTION
shutilwhich is imported in the main app (not tests) and not part of shutil is the base python distro, require it as a pip dependency