### PR TITLE
run_tests.yml: test against multiple pandoc versions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,6 +44,7 @@ jobs:
         flake8 ./panflute --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Download Pandoc
       run: |
+        pip install requests
         downloadUrl=$(python -c 'import requests, sys; v = sys.argv[1]; url = "https://api.github.com/repos/jgm/pandoc/releases/" + ("" if v == "latest" else "tags/") + v; print(next(i["browser_download_url"] for i in requests.get(url).json()["assets"] if i["name"][-3:] == "deb"))' ${{ matrix.pandoc-version }})
         wget $downloadUrl
         sudo dpkg -i ${downloadUrl##*/}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, pypy3]
         # last 1.x verison
-        pandoc-version: [1.19.2.4, 2.0.6, 2.1.3, 2.2.3.2, 2.3.1, 2.4, 2.5, 2.6, 2.7.3, 2.8.1, 2.9.2.1, latest]
+        pandoc-version: [2.7.3, 2.8.1, latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,9 +21,16 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, pypy3]
-        # last 1.x verison
-        pandoc-version: [2.7.3, 2.8.1, latest]
+        # see setup.py for supported versions
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        # pandoc testing versions note:
+        # lowest supported version is 2.7
+        # no major API change between 2.7 to 2.9
+        # 2.10 has breaking change
+        # 2.11 has minor breaking change, fixing some quirks in 2.10
+        # should test sparingly across API breaking boundaries
+        # as of writing, panflute only support pandoc<= 2.9. But GitHub workflow does not support "allow failure" yet. See https://github.com/actions/toolkit/issues/399
+        pandoc-version: [2.7.3, 2.9.2.1, 2.10.1, latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, pypy3]
         # last 1.x verison
-        pandoc-version: [1.19.2.1, 2.9.2.1, latest]
+        pandoc-version: [1.19.2.4, 2.0.6, 2.1.3, 2.2.3.2, 2.3.1, 2.4, 2.5, 2.6, 2.7.3, 2.8.1, 2.9.2.1, latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,14 +23,19 @@ jobs:
       matrix:
         # see setup.py for supported versions
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
-        # pandoc testing versions note:
-        # lowest supported version is 2.7
-        # no major API change between 2.7 to 2.9
-        # 2.10 has breaking change
-        # 2.11 has minor breaking change, fixing some quirks in 2.10
         # should test sparingly across API breaking boundaries
-        # as of writing, panflute only support pandoc<= 2.9. But GitHub workflow does not support "allow failure" yet. See https://github.com/actions/toolkit/issues/399
-        pandoc-version: [2.7.3, 2.9.2.1, 2.10.1, latest]
+        pandoc-version:
+          # panflute only support at or above this
+          - 2.7.3
+          # no major API change between 2.7 to 2.9
+          # - 2.8.1
+          - 2.9.2.1
+          # as of writing, panflute only support pandoc<= 2.9. But GitHub workflow does not support "allow failure" yet. See https://github.com/actions/toolkit/issues/399
+          # 2.10 has breaking change
+          - 2.10.1
+          # 2.11 has minor breaking change, fixing some quirks in 2.10
+          # - 2.11.1
+          - latest
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,9 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8] # , pypy3]
+        python-version: [3.6, 3.7, 3.8, pypy3]
+        # last 1.x verison
+        pandoc-version: [1.19.2.1, 2.9.2.1, latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -42,12 +44,9 @@ jobs:
         flake8 ./panflute --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Download Pandoc
       run: |
-        url="https://github.com/jgm/pandoc/releases/latest"
-        path=$(curl -L $url | grep -o '/jgm/pandoc/releases/download/.*-amd64\.deb')
-        downloadUrl="https://github.com$path"
-        file=${path##*/}
-        wget $downloadUrl &&
-        sudo dpkg -i $file
+        downloadUrl=$(python -c 'import requests, sys; v = sys.argv[1]; url = "https://api.github.com/repos/jgm/pandoc/releases/" + ("" if v == "latest" else "tags/") + v; print(next(i["browser_download_url"] for i in requests.get(url).json()["assets"] if i["name"][-3:] == "deb"))' ${{ matrix.pandoc-version }})
+        wget $downloadUrl
+        sudo dpkg -i ${downloadUrl##*/}
         pandoc --version
     - name: Test with pytest
       run: |

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
This PR add pypy3 test, and also test against multiple pandoc versions.

May not be ready to merged if discussion of supported pandoc versions is needed. By the way, is it mentioned somewhere in the doc which pandoc versions are supported?

By the way, the run test and publish workflow can be combined into one. E.g. setup in <https://github.com/ickc/pantable/blob/master/.github/workflows/pythonpackage.yml>.

Edit: seems like pandoc v1 support is dropped as shown in <https://github.com/ickc/panflute/runs/676485536>.

Edit2: pypy3 is added because it is stated as a supporting platform in `setup.py`.

Edit3: from [CI](https://github.com/ickc/panflute/actions/runs/105202745) seems like only down to pandoc 2.7 is supported.