### PR TITLE
remove object_pairs_hook and OrderedDict

### DIFF
--- a/panflute/base.py
+++ b/panflute/base.py
@@ -7,7 +7,6 @@ Base classes and methods of all Pandoc elements
 # ---------------------------
 
 from operator import attrgetter
-from collections import OrderedDict
 from collections.abc import MutableSequence, MutableMapping
 from itertools import chain
 
@@ -52,7 +51,7 @@ class Element(object):
         for key in self.__slots__:
             if not key.startswith('_') and key != 'text':
                 val = getattr(self, key)
-                if val not in ([], OrderedDict(), ''):
+                if val not in ([], dict(), ''):
                     extra.append([key, val])
 
         if extra:
@@ -83,7 +82,7 @@ class Element(object):
     def _set_ica(self, identifier, classes, attributes):
         self.identifier = check_type(identifier, str)
         self.classes = [check_type(cl, str) for cl in classes]
-        self.attributes = OrderedDict(attributes)
+        self.attributes = dict(attributes)
 
     def _ica_to_json(self):
         return [self.identifier, self.classes, list(self.attributes.items())]

--- a/panflute/containers.py
+++ b/panflute/containers.py
@@ -7,7 +7,6 @@ object, and the attribute of the parent object that they correspond to.
 # Imports
 # ---------------------------
 
-from collections import OrderedDict
 from collections.abc import MutableSequence, MutableMapping
 from .utils import check_type, encode_dict  # check_group
 
@@ -15,7 +14,7 @@ from .utils import check_type, encode_dict  # check_group
 # ---------------------------
 # Container Classes
 # ---------------------------
-# These are list and OrderedDict containers that
+# These are list and dict containers that
 #  (a) track the identity of their parents, and
 #  (b) track the parent's property where they are stored
 # They attach these two to the elements requested through __getattr__
@@ -107,7 +106,7 @@ class DictContainer(MutableMapping):
         self.parent = parent
         self.location = None
 
-        self.dict = OrderedDict()
+        self.dict = dict()
         self.update(args)  # Must be a sequence of tuples
         self.update(kwargs)  # Order of kwargs is not preserved
 
@@ -137,9 +136,7 @@ class DictContainer(MutableMapping):
         return self.dict.__iter__()
 
     def to_json(self):
-        items = self.dict.items()
-        return OrderedDict((k, to_json_wrapper(v)) for k, v in items)
-        return [item.to_json() for item in self.dict]
+        return {k: to_json_wrapper(v) for k, v in self.dict.items()}
 
 
 # ---------------------------

--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -83,7 +83,7 @@ class Doc(Element):
             return {
                 'pandoc-api-version': self.api_version,
                 'meta': meta,
-                'blocks']: blocks,
+                'blocks': blocks,
             }
 
 

--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -6,8 +6,6 @@ Classes corresponding to Pandoc elements
 # Imports
 # ---------------------------
 
-from collections import OrderedDict
-
 from .utils import check_type, check_group, encode_dict
 from .containers import ListContainer, DictContainer
 from .base import Element, Block, Inline, MetaValue
@@ -71,10 +69,7 @@ class Doc(Element):
 
     @metadata.setter
     def metadata(self, value):
-        if isinstance(value, MetaMap):
-            value = value.content
-        else:
-            value = OrderedDict(value)
+        value = value.content if isinstance(value, MetaMap) else dict(value)
         self._metadata = MetaMap(*value.items())
 
     def to_json(self):
@@ -85,11 +80,11 @@ class Doc(Element):
         if self.api_version is None:
             return [{'unMeta': meta}, blocks]
         else:
-            ans = OrderedDict()
-            ans['pandoc-api-version'] = self.api_version
-            ans['meta'] = meta
-            ans['blocks'] = blocks
-            return ans
+            return {
+                'pandoc-api-version': self.api_version,
+                'meta': meta,
+                'blocks']: blocks,
+            }
 
 
 # ---------------------------
@@ -534,25 +529,25 @@ class Citation(Element):
 
     def to_json(self):
         # Replace default .to_json ; we don't need _slots_to_json()
-        ans = OrderedDict()
-        ans['citationSuffix'] = self.suffix.to_json()
-        ans['citationNoteNum'] = self.note_num
-        ans['citationMode'] = {'t': self.mode}
-        ans['citationPrefix'] = self.prefix.to_json()
-        ans['citationId'] = self.id
-        ans['citationHash'] = self.hash
-        return ans
+        return {
+            'citationSuffix': self.suffix.to_json(),
+            'citationNoteNum': self.note_num,
+            'citationMode': {'t': self.mode},
+            'citationPrefix': self.prefix.to_json(),
+            'citationId': self.id,
+            'citationHash': self.hash,
+        }
 
     def to_json_legacy(self):
         # Replace default .to_json ; we don't need _slots_to_json()
-        ans = OrderedDict()
-        ans['citationSuffix'] = self.suffix.to_json()
-        ans['citationNoteNum'] = self.note_num
-        ans['citationMode'] = encode_dict(self.mode, [])
-        ans['citationPrefix'] = self.prefix.to_json()
-        ans['citationId'] = self.id
-        ans['citationHash'] = self.hash
-        return ans
+        return {
+            'citationSuffix': self.suffix.to_json(),
+            'citationNoteNum': self.note_num,
+            'citationMode': encode_dict(self.mode, []),
+            'citationPrefix': self.prefix.to_json(),
+            'citationId': self.id,
+            'citationHash': self.hash,
+        }
 
 
 class Link(Inline):
@@ -1405,11 +1400,6 @@ def _decode_row(row):
 
 
 def from_json(data):
-
-    # OrderedDict should be fast in 3.6+, so don't worry about speed:
-    # https://twitter.com/raymondh/status/773978885092323328
-    data = OrderedDict(data)
-
     # Metadata key (legacy)
     if 'unMeta' in data:
         assert len(data) == 1

--- a/panflute/io.py
+++ b/panflute/io.py
@@ -18,7 +18,6 @@ import os
 import sys
 import json
 import codecs  # Used in sys.stdout writer
-from collections import OrderedDict
 from functools import partial
 
 
@@ -56,7 +55,7 @@ def load(input_stream=None):
         input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
 
     # Load JSON and validate it
-    doc = json.load(input_stream, object_pairs_hook=from_json)
+    doc = json.load(input_stream, object_hook=from_json)
 
     # Notes:
     # - We use 'object_pairs_hook' instead of 'object_hook' to preserve the
@@ -271,5 +270,5 @@ def load_reader_options():
     Retrieve Pandoc Reader options from the environment
     """
     options = os.environ['PANDOC_READER_OPTIONS']
-    options = json.loads(options, object_pairs_hook=OrderedDict)
+    options = json.loads(options)
     return options

--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -261,8 +261,7 @@ def meta2builtin(meta):
     elif isinstance(meta, MetaList):
         return [meta2builtin(v) for v in meta.content.list]
     elif isinstance(meta, MetaMap):
-        return OrderedDict((k, meta2builtin(v)) for (k, v)
-                           in meta.content.dict.items())
+        return {k: meta2builtin(v) for k, v in meta.content.dict.items()}
     elif isinstance(meta, (MetaInlines, MetaBlocks)):
         return stringify(meta)
     else:
@@ -418,7 +417,7 @@ def convert_text(text,
     out = inner_convert_text(text, in_fmt, out_fmt, extra_args)
 
     if output_format == 'panflute':
-        out = json.loads(out, object_pairs_hook=from_json)
+        out = json.loads(out, object_hook=from_json)
 
         if standalone:
             if not isinstance(out, Doc):  # Pandoc 1.7.2 and earlier

--- a/panflute/utils.py
+++ b/panflute/utils.py
@@ -6,7 +6,6 @@ Auxiliary functions that have no dependencies
 # Imports
 # ---------------------------
 
-from collections import OrderedDict
 import sys
 import os.path as p
 from importlib import import_module
@@ -70,7 +69,10 @@ def check_group(value, group):
 
 
 def encode_dict(tag, content):
-    return OrderedDict((("t", tag), ("c", content)))
+    return {
+        "t": tag,
+        "c": content,
+    }
 
 
 # ---------------------------


### PR DESCRIPTION
- elements.from_json now expects dict input rather than list of tuples
- io.load calls json.load with object_hook instead of object_pairs_hook
- removes all traces of OrderedDict

Because we're now support Python 3.6+ only, and dict in both CPython and pypy 3.6+ is now guaranteed to be ordered (it is an implementation detail in 3.6, guaranteed in 3.7+, so all 3.6+'s dict are ordered)

**It avoids json.loads packing them in list of tuples and panflute converting it back to dict in elements.from_json**