### PR TITLE
tools.py: convert_text, run_pandoc add pandoc_path option

### DIFF
--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -292,16 +292,14 @@ def shell(args, wait=True, msg=None):
         proc = Popen(args, creationflags=DETACHED_PROCESS)
 
 
-def run_pandoc(text='', args=None):
+def run_pandoc(text='', args=None, pandoc_path=which('pandoc')):
     """
     Low level function that calls Pandoc with (optionally)
     some input text and/or arguments
     """
-
     if args is None:
         args = []
 
-    pandoc_path = which('pandoc')
     if pandoc_path is None or not os.path.exists(pandoc_path):
         raise OSError("Path to pandoc executable does not exists")
 
@@ -319,7 +317,8 @@ def convert_text(text,
                  input_format='markdown',
                  output_format='panflute',
                  standalone=False,
-                 extra_args=None):
+                 extra_args=None,
+                 pandoc_path=which('pandoc')):
     r"""
     Convert formatted text (usually markdown) by calling Pandoc internally
 
@@ -387,7 +386,7 @@ def convert_text(text,
     if standalone:
         extra_args.append('--standalone')
 
-    out = inner_convert_text(text, in_fmt, out_fmt, extra_args)
+    out = inner_convert_text(text, in_fmt, out_fmt, extra_args, pandoc_path=pandoc_path)
 
     if output_format == 'panflute':
         out = json.loads(out, object_hook=from_json)
@@ -405,12 +404,12 @@ def convert_text(text,
     return out
 
 
-def inner_convert_text(text, input_format, output_format, extra_args):
+def inner_convert_text(text, input_format, output_format, extra_args, pandoc_path=which('pandoc')):
     # like convert_text(), but does not support 'panflute' input/output
     from_arg = '--from={}'.format(input_format)
     to_arg = '--to={}'.format(output_format)
     args = [from_arg, to_arg] + extra_args
-    out = run_pandoc(text, args)
+    out = run_pandoc(text, args, pandoc_path=pandoc_path)
     out = "\n".join(out.splitlines())  # Replace \r\n with \n
     return out
 

--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -23,6 +23,9 @@ from shutil import which
 from subprocess import Popen, PIPE
 from functools import partial
 
+# to be filled when the first time which('pandoc') is called
+PANDOC_PATH = None
+
 
 # ---------------------------
 # Constants
@@ -292,18 +295,29 @@ def shell(args, wait=True, msg=None):
         proc = Popen(args, creationflags=DETACHED_PROCESS)
 
 
-def run_pandoc(text='', args=None, pandoc_path=which('pandoc')):
+def run_pandoc(text='', args=None, pandoc_path=None):
     """
     Low level function that calls Pandoc with (optionally)
     some input text and/or arguments
+
+    :param str pandoc_path: If specified, use the pandoc at this path.
+        If None, default to that from PATH.
     """
     if args is None:
         args = []
+    if pandoc_path is None:
+        # initialize the global PANDOC_PATH
+        if PANDOC_PATH is None:
+            temp = which('pandoc')
+            if temp is None:
+                raise OSError("Path to pandoc executable does not exists")
+            sys.modules[__name__].PANDOC_PATH = temp
+        pandoc_path = PANDOC_PATH
 
-    if pandoc_path is None or not os.path.exists(pandoc_path):
-        raise OSError("Path to pandoc executable does not exists")
-
-    proc = Popen([pandoc_path] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    try:
+        proc = Popen([pandoc_path] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    except FileNotFoundError:
+        raise OSError(f"Given pandoc_path {pandoc_path} is invalid")
     out, err = proc.communicate(input=text.encode('utf-8'))
     exitcode = proc.returncode
     if err:
@@ -318,7 +332,7 @@ def convert_text(text,
                  output_format='panflute',
                  standalone=False,
                  extra_args=None,
-                 pandoc_path=which('pandoc')):
+                 pandoc_path=None):
     r"""
     Convert formatted text (usually markdown) by calling Pandoc internally
 
@@ -351,6 +365,8 @@ def convert_text(text,
     :type standalone: :class:`bool`
     :param extra_args: extra arguments passed to Pandoc
     :type extra_args: :class:`list`
+    :param str pandoc_path: If specified, use the pandoc at this path.
+        If None, default to that from PATH.
     :rtype: :class:`list` | :class:`.Doc` | :class:`str`
 
     Note: for a more general solution,
@@ -404,7 +420,7 @@ def convert_text(text,
     return out
 
 
-def inner_convert_text(text, input_format, output_format, extra_args, pandoc_path=which('pandoc')):
+def inner_convert_text(text, input_format, output_format, extra_args, pandoc_path=None):
     # like convert_text(), but does not support 'panflute' input/output
     from_arg = '--from={}'.format(input_format)
     to_arg = '--to={}'.format(output_format)


### PR DESCRIPTION
two fold:
- provide option to control pandoc_path when used as a library
- in principle faster since "which" is called once and cached, so multiple call to them has reduced latency