### PR TITLE
Support pandoc 2.12+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build source distribution
         run: |
-          python3 setup.py sdist
+          python3 setup.py sdist bdist_wheel
           twine check dist/*
 
       - name: Publish distribution to Test PyPI

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click=${{ matrix.click-version }}
+        python -m pip install click==${{ matrix.click-version }}
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,6 +58,8 @@ jobs:
        mkdir -p $HOME/.pandoc/filters
        find ./examples/panflute ./docs/source/_static -iname '*.py' -exec cp {} $HOME/.pandoc/filters/ \;
        find . -iname '*.md' -print0 | xargs -0 -i -n1 -P4 bash -c 'pandoc -t native -F panflute -o $0.native $0' {}
+    - name: Test panfl cli
+      run: panfl --help
 
 # put filters in $DATADIR for panflute's autofilter
 # running all available .md files through panflute

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,6 +31,9 @@ jobs:
         click-version:
           - 6
           - 7
+        pyyaml-version:
+          - 3
+          - 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click==${{ matrix.click-version }}
+        python -m pip install click==${{ matrix.click-version }} pyyaml==${{ matrix.pyyaml-version }}
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,6 +28,9 @@ jobs:
           # earliest supported pandoc version
           - 2.11.0.4
           - latest
+        click-version:
+          - 6
+          - 7
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[dev]"
+        python -m pip install click=${{ matrix.click-version }}
+        python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,14 +27,14 @@ jobs:
         pandoc-version:
           # earliest supported pandoc version
           - 2.11.0.4
-          - 2.11.1
-          - 2.11.1.1
-          - 2.11.2
-          - 2.11.3
-          - 2.11.3.1
-          - 2.11.3.2
-          - 2.11.4
-          - 2.12
+          # - 2.11.1
+          # - 2.11.1.1
+          # - 2.11.2
+          # - 2.11.3
+          # - 2.11.3.1
+          # - 2.11.3.2
+          # - 2.11.4
+          # - 2.12
           - latest
         # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -71,8 +71,8 @@ jobs:
       run: pytest --color=yes
     - name: Test by running existing filters
       run: |
-       mkdir -p $HOME/.pandoc/filters
-       find ./examples/panflute ./docs/source/_static -iname '*.py' -exec cp {} $HOME/.pandoc/filters/ \;
+       mkdir -p $HOME/.local/share/pandoc/filters
+       find ./examples/panflute ./docs/source/_static -iname '*.py' -exec cp {} $HOME/.local/share/pandoc/filters \;
        find . -iname '*.md' -print0 | xargs -0 -i -n1 -P4 bash -c 'pandoc -t native -F panflute -o $0.native $0' {}
     - name: Test panfl cli
       run: panfl --help

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,11 +29,11 @@ jobs:
           - 2.11.0.4
           - latest
         click-version:
-          - 6
-          - 7
+          - 'click>=6,<7'
+          - 'click>=7,<8'
         pyyaml-version:
-          - 3
-          - 5
+          - 'pyyaml>=3,<4'
+          - 'pyyaml>=5,<6'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click==${{ matrix.click-version }} pyyaml==${{ matrix.pyyaml-version }}
+        python -m pip install "${{ matrix.click-version }}" "${{ matrix.pyyaml-version }}"
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,6 +27,14 @@ jobs:
         pandoc-version:
           # earliest supported pandoc version
           - 2.11.0.4
+          - 2.11.1
+          - 2.11.1.1
+          - 2.11.2
+          - 2.11.3
+          - 2.11.3.1
+          - 2.11.3.2
+          - 2.11.4
+          - 2.12
           - latest
         # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,11 +28,12 @@ jobs:
           # earliest supported pandoc version
           - 2.11.0.4
           - latest
+        # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:
-          - 'click>=6,<7'
+          # - 'click>=6,<7'
           - 'click>=7,<8'
         pyyaml-version:
-          - 'pyyaml>=3,<4'
+          # - 'pyyaml>=3,<4'
           - 'pyyaml>=5,<6'
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 Panflute uses [Sphinx](http://www.sphinx-doc.org/) for its documentation.
 To install it, install Python 3.3+ and then run `pip install sphinx` (or see [here](http://www.sphinx-doc.org/en/1.4.8/install.html)).
 
-To build the documentation, navigate to the `/docs` folder and type `make html`. The build files will then be placed in `/docs/build/html`, an can be copied into a [website](scorreia.com/software/panflute/)
+To build the documentation, navigate to the `/docs` folder and type `make html`. The build files will then be placed in `/docs/build/html`, and can be copied into a [website](scorreia.com/software/panflute/)
 
 The guides are written in [REST](http://www.sphinx-doc.org/en/stable/rest.html) and located in the [/docs/source](https://github.com/sergiocorreia/panflute/tree/master/docs/source) folder.
 

--- a/README.md
+++ b/README.md
@@ -15,45 +15,37 @@ If you want to contribute, head [here](/CONTRIBUTING.md).
 You might also find useful [this presentation](https://github.com/BPLIM/Workshops/raw/master/BPLIM2019/D2_S1_Sergio_Correia_Markdown.pdf) on how I use markdown+pandoc+panflute to write research papers (at the Banco de Portugal 2019 Workshop on Reproductible Research).
 
 
-## Install
+## Installation
 
-To install panflute, open the command line and type:
+### Pip
 
-```bash
-pip install panflute
-```
+To manage panflute using pip, open the command line and run
 
-## Upgrade
+- `pip install panflute` to install
+- `pip install -U panflute` to upgrade
+- `pip uninstall panflute` to remove
 
-To upgrade panflute, open the command line and type:
+You need a matching pandoc version for panflute to work flawlessly. See [Supported pandoc versions] for details. Or, use the [Conda] method to install below to have the pandoc version automatically managed for you.
 
-```bash
-pip install panflute -U
-```
+### Conda
 
-## Uninstall
+To manage panflute with a matching pandoc version, open the command line and run
 
-To uninstall panflute, open the command line and type:
+- `conda install -c conda-forge pandoc 'panflute>=2.0.5'` to install both
+- `conda update pandoc panflute` to upgrade both
+- `conda remove pandoc panflute` to remove both
 
-```bash
-pip uninstall panflute
-```
+You may also replace `conda` by `mamba`, which is basically a drop-in replacement of the conda package manager. See [mamba-org/mamba: The Fast Cross-Platform Package Manager](https://github.com/mamba-org/mamba) for details.
 
-## Dev Install
+### Note on versions
 
-After cloning the repo and opening the panflute folder:
-
-`python setup.py install`: installs the package locally
-
-`python setup.py develop`: installs locally with a symlink so changes are automatically updated
-
-## Note on versions
+#### Supported Python versions
 
 panflute 1.12 or above dropped support of Python 2. When using Python 3, depending on your setup, you may need to use `pip3`/`python3` explicitly. If you need to use panflute in Python 2, install panflute 1.11.x or below.
 
 Currently supported Python versions: [![Python version](https://img.shields.io/pypi/pyversions/panflute.svg)](https://pypi.python.org/pypi/panflute/). Check `setup.py` for details, which further indicates support of pypy on top of CPython.
 
-### Supported pandoc versions
+#### Supported pandoc versions
 
 pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org) and panflute's is MAJOR.MINOR.PATCH. Below we shows matching versions of pandoc that panflute supports, in descending order. Only major version is shown as long as the minor versions doesn't matter.
 
@@ -66,6 +58,13 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 | 1.12 | 2.7-2.9 | 1.17.5–1.20  |
 
 Note: pandoc 2.10 is short lived and 2.11 has minor API changes comparing to that, mainly for fixing its shortcomings. Please avoid using pandoc 2.10.
+
+## Dev Install
+
+After cloning the repo and opening the panflute folder, run
+
+- `python setup.py install` to install the package locally
+- `python setup.py develop` to install locally with a symlink so changes are automatically updated
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 
 | panflute version  | supported pandoc versions | supported pandoc API versions |
 | ---   | ---   |  ---  |
-| 2.0 | 2.11.0.4—2.11.x  | 1.22    |
+| 2.0 | 2.11.0.4—2.13.x  | 1.22    |
 | not supported | 2.10  | 1.21  |
 | 1.12 | 2.7-2.9 | 1.17.5–1.20  |
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 
 | panflute version  | supported pandoc versions | supported pandoc API versions |
 | ---   | ---   |  ---  |
-| 2.0 | 2.11.0.4—2.13.x  | 1.22    |
+| 2.1 | 2.11.0.4—2.13.x  | 1.22    |
+| 2.0 | 2.11.0.4—2.11.x  | 1.22    |
 | not supported | 2.10  | 1.21  |
 | 1.12 | 2.7-2.9 | 1.17.5–1.20  |
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,14 +5,12 @@ To install panflute from PyPI, open the command line and type::
 
     pip install panflute
 
-- Works with Python 3.3+, Python 2.7 and PyPy
+- Works with Python 3.6+, and PyPy
 - On Windows, you might need to open the command line (``cmd``)  as administrator (`ctrl+shift+enter`).
 
 To install the latest Github version of panflute, type::
 
     pip install git+git://github.com/sergiocorreia/panflute.git
-
-- Note that the Github version requires Python 3.3+ (but supports intellisense-like tools)
 
 
 Dev Install

--- a/panflute/autofilter.py
+++ b/panflute/autofilter.py
@@ -32,25 +32,23 @@ def get_filter_dirs(hardcoded=True):
             d1 = base / 'pandoc' / 'filters'
             return [str(d1)]
         else:
+            from .tools import pandoc_version
+
+            version = pandoc_version.version
             base = Path(os.environ['HOME'])
-            d1 = base / '.pandoc' / 'filters'
-            d2 = base / '.local' / 'share' / 'pandoc' / 'filters'
-            return [str(d1), str(d2)]
+            res = []
+            # str below to convert from Path to str is necessary
+            # for test_panfl.test_get_filter_dirs
+            # and also for consistencies of the return types in the 
+            # pandoc 2.12 dropped this historical convention
+            if version[:2] < (2, 12):
+                res.append(str(base / '.pandoc' / 'filters'))
+            res.append(str(base / '.local' / 'share' / 'pandoc' / 'filters'))
+            return res
     else:
-        from .tools import run_pandoc
+        from .tools import pandoc_version
 
-        # Extract $DATADIR
-        info = run_pandoc(args=['--version']).splitlines()
-        prefix = "User data directory: "
-        info = [row for row in info if row.startswith(prefix)]
-        assert len(info) == 1, info
-        data_dir = info[0][len(prefix):]
-
-        # data_dir might contain multiple folders:
-        # Default user data directory: /home/runner/.local/share/pandoc or /home/runner/.pandoc/filters
-        data_dir = data_dir.split(' or ')
-        data_dir = [p.normpath(p.expanduser(p.expandvars(p.join(d, 'filters')))) for d in data_dir]
-        return data_dir
+        return pandoc_version.data_dir
 
 
 def stdio(filters=None, search_dirs=None, data_dir=True, sys_path=True,

--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -13,11 +13,13 @@ from .io import dump
 
 import io
 import os
+import os.path as p
 import re
 import sys
 import json
 import yaml
 import shlex
+from typing import Tuple
 
 from shutil import which
 from subprocess import Popen, PIPE
@@ -34,6 +36,55 @@ PANDOC_PATH = None
 HorizontalSpaces = (Space, LineBreak, SoftBreak)
 
 VerticalSpaces = (Para, )
+
+
+# ---------------------------
+# Convenience classes
+# ---------------------------
+
+
+class PandocVersion:
+    '''get runtime pandoc verison
+
+    use PandocVersion().version for comparing versions
+    '''
+
+    def __init__(self):
+        pass
+
+    def __str__(self) -> str:
+        return self._repr.splitlines()[0].split(' ')[1]
+
+    def __repr__(self) -> str:
+        return self._repr
+
+    @property
+    def _repr(self):
+        # lazily call pandoc only once
+        if not hasattr(self, '__repr'):
+            self.__repr: str = run_pandoc(args=['--version'])
+        return self.__repr
+
+    @property
+    def version(self) -> Tuple[int, ...]:
+        return tuple(int(i) for i in str(self).split('.'))
+
+    @property
+    def data_dir(self):
+        info = self._repr.splitlines()
+        prefix = "User data directory: "
+        info = [row for row in info if row.startswith(prefix)]
+        assert len(info) == 1, info
+        data_dir = info[0][len(prefix):]
+
+        # data_dir might contain multiple folders:
+        # Default user data directory: /home/runner/.local/share/pandoc or /home/runner/.pandoc/filters
+        data_dir = data_dir.split(' or ')
+        data_dir = [p.normpath(p.expanduser(p.expandvars(p.join(d, 'filters')))) for d in data_dir]
+        return data_dir
+
+
+pandoc_version = PandocVersion()
 
 
 # ---------------------------

--- a/panflute/version.py
+++ b/panflute/version.py
@@ -2,4 +2,4 @@
 Panflute version
 """
 
-__version__ = '2.0.5'
+__version__ = '2.1.0'

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
 
-    python_requires='>=3.6,<4',
+    python_requires='>=3.6',
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'click >=7,<8',
-        'pyyaml >=5,<6',
+        'click >=6,<8',
+        'pyyaml >=3,<6',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
The develop branch currently contains minor PRs that is (hopefully) non-controversial and backward compatible. It is created to be merged during release phase so that the author can batch review this.

This PR includes:

- #174
- #175
- #176
- #179
- #185
- #186

And among those, these are slightly less trivial and should be looked at more carefully:

- #174: convert_text, run_pandoc add pandoc_path option
- #185: Support pandoc 2.12+, which adds PandocVersion to put all `pandoc --version` related operations together and call pandoc only once

Edit: This PR also add pandoc 2.12+ support hence bump panflute version to 2.1.0.