### PR TITLE
Improve dep version constraints

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click=${{ matrix.click-version }}
+        python -m pip install click==${{ matrix.click-version }}
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,6 +58,8 @@ jobs:
        mkdir -p $HOME/.pandoc/filters
        find ./examples/panflute ./docs/source/_static -iname '*.py' -exec cp {} $HOME/.pandoc/filters/ \;
        find . -iname '*.md' -print0 | xargs -0 -i -n1 -P4 bash -c 'pandoc -t native -F panflute -o $0.native $0' {}
+    - name: Test panfl cli
+      run: panfl --help
 
 # put filters in $DATADIR for panflute's autofilter
 # running all available .md files through panflute

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,6 +31,9 @@ jobs:
         click-version:
           - 6
           - 7
+        pyyaml-version:
+          - 3
+          - 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click==${{ matrix.click-version }}
+        python -m pip install click==${{ matrix.click-version }} pyyaml==${{ matrix.pyyaml-version }}
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,6 +28,9 @@ jobs:
           # earliest supported pandoc version
           - 2.11.0.4
           - latest
+        click-version:
+          - 6
+          - 7
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[dev]"
+        python -m pip install click=${{ matrix.click-version }}
+        python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,11 +29,11 @@ jobs:
           - 2.11.0.4
           - latest
         click-version:
-          - 6
-          - 7
+          - 'click>=6,<7'
+          - 'click>=7,<8'
         pyyaml-version:
-          - 3
-          - 5
+          - 'pyyaml>=3,<4'
+          - 'pyyaml>=5,<6'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install click==${{ matrix.click-version }} pyyaml==${{ matrix.pyyaml-version }}
+        python -m pip install "${{ matrix.click-version }}" "${{ matrix.pyyaml-version }}"
         python -m pip install ".[dev]"
     - name: Lint with flake8
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,11 +28,12 @@ jobs:
           # earliest supported pandoc version
           - 2.11.0.4
           - latest
+        # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:
-          - 'click>=6,<7'
+          # - 'click>=6,<7'
           - 'click>=7,<8'
         pyyaml-version:
-          - 'pyyaml>=3,<4'
+          # - 'pyyaml>=3,<4'
           - 'pyyaml>=5,<6'
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
 
-    python_requires='>=3.6,<4',
+    python_requires='>=3.6',
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'click >=7,<8',
-        'pyyaml >=5,<6',
+        'click >=6,<8',
+        'pyyaml >=3,<6',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
c.f. #173

I tested various pyyaml and click versions in https://github.com/ickc/panflute/actions/runs/441717836

As they pass, we expand the allowed versions in setup.py

Also remove the python<4 constraint as there's no plan for its arrival yet.