### PR TITLE
panflute 2.1.2 release

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,7 +39,7 @@ jobs:
         # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:
           # - 'click>=6,<7'
-          - 'click>=7,<8'
+          # - 'click>=7,<8'
           - 'click>=8,<9'
         pyyaml-version:
           # - 'pyyaml>=3,<4'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,7 +35,6 @@ jobs:
           # - 2.11.3.2
           # - 2.11.4
           # - 2.12
-          - 2.14
           - latest
         # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,6 +35,7 @@ jobs:
           # - 2.11.3.2
           # - 2.11.4
           # - 2.12
+          - 2.14
           - latest
         # tests multiple versions of `install_requires` when we want to expand the support matrix
         click-version:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Panflute: Pythonic Pandoc Filters
 
-[![Python version](https://img.shields.io/pypi/pyversions/panflute.svg)](https://pypi.python.org/pypi/panflute/)
-[![PyPI version](https://img.shields.io/pypi/v/panflute.svg)](https://pypi.python.org/pypi/panflute/)
 [![Development Status](https://img.shields.io/pypi/status/panflute.svg)](https://pypi.python.org/pypi/panflute/)
 [![Build Status](https://github.com/sergiocorreia/panflute/workflows/CI%20Tests/badge.svg)](https://github.com/sergiocorreia/panflute/actions?query=workflow%3A%22CI+Tests%22)
+![License](https://img.shields.io/pypi/l/panflute.svg)
 [![DOI](https://zenodo.org/badge/55024750.svg)](https://zenodo.org/badge/latestdoi/55024750)
+
+[![GitHub Releases](https://img.shields.io/github/tag/sergiocorreia/panflute.svg?label=github+release)](https://github.com/sergiocorreia/panflute/releases)
+[![PyPI version](https://img.shields.io/pypi/v/panflute.svg)](https://pypi.python.org/pypi/panflute/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/panflute.svg)](https://anaconda.org/conda-forge/panflute)
+[![Python version](https://img.shields.io/pypi/pyversions/panflute.svg)](https://pypi.python.org/pypi/panflute/)
+[![Supported implementations](https://img.shields.io/pypi/implementation/panflute.svg)](https://pypi.org/project/panflute)
 
 [panflute](http://scorreia.com/software/panflute/) is a Python package that makes creating Pandoc filters fun.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 
 | panflute version  | supported pandoc versions | supported pandoc API versions |
 | ---   | ---   |  ---  |
-| 2.1 | 2.11.0.4—2.13.x  | 1.22    |
+| 2.1 | 2.11.0.4—2.14.x  | 1.22    |
 | 2.0 | 2.11.0.4—2.11.x  | 1.22    |
 | not supported | 2.10  | 1.21  |
 | 1.12 | 2.7-2.9 | 1.17.5–1.20  |

--- a/panflute/version.py
+++ b/panflute/version.py
@@ -2,4 +2,4 @@
 Panflute version
 """
 
-__version__ = '2.1.0'
+__version__ = '2.1.2'


### PR DESCRIPTION
Summary:

- document the support of pandoc 2.14
- add badges,
    - add info on distributed versions on GitHub Releases, conda-forge. Ideally, these 3 versions should be consistent. See <https://github.com/sergiocorreia/panflute/pull/193#issuecomment-860027299>.
    - add license