### PR TITLE
Fix build time warning from setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.md


### PR DESCRIPTION
When running `python setup.py test` I was getting the following error:

> /usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead

In the interest of keeping the output clean so any future warnings that actually matter stand a chance of getting noticed, I suggest just doing what it wants.

