### PR TITLE
Don't block Click v8, seems to work fine

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,6 +40,7 @@ jobs:
         click-version:
           # - 'click>=6,<7'
           - 'click>=7,<8'
+          - 'click>=8,<9'
         pyyaml-version:
           # - 'pyyaml>=3,<4'
           - 'pyyaml>=5,<6'

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'click >=6,<8',
+        'click >=6,<9',
         'pyyaml >=3,<6',
     ],
 


### PR DESCRIPTION
Note Arch packaging has been using this against Click v8 for some time,
the requirements file doesn't specify versions at all and only the test
function was failing because of this version locking.
