### PR TITLE
panflute v2.1.3: Support pandoc 2.16 & upgrade dependencies

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 5
       matrix:
         # see setup.py for supported versions
-        # here instead of having a matrix to test against 7 * 7 * 3 * 4 combinations
+        # here instead of having a matrix to test against 7 * 7 * 3 * 3 combinations
         # we only test 7 combinations in a round-robin fashion
         include:
           - python-version: "3.6"
@@ -32,27 +32,27 @@ jobs:
           - python-version: "pypy-3.6"
             pandoc-version: "2.12"
             click-version: "click>=7,<8"
-            pyyaml-version: "pyyaml>=4,<5"
+            pyyaml-version: "pyyaml>=5,<6"
           - python-version: "3.7"
             pandoc-version: "2.13"
             click-version: "click>=8,<9"
-            pyyaml-version: "pyyaml>=5,<6"
+            pyyaml-version: "pyyaml>=6,<7"
           - python-version: "pypy-3.7"
             pandoc-version: "2.14.2"
             click-version: "click>=6,<7"
-            pyyaml-version: "pyyaml>=6,<7"
+            pyyaml-version: "pyyaml>=3,<4"
           - python-version: "3.8"
             pandoc-version: "2.15"
             click-version: "click>=7,<8"
-            pyyaml-version: "pyyaml>=3,<4"
+            pyyaml-version: "pyyaml>=5,<6"
           - python-version: "3.9"
             pandoc-version: "2.16.2"
             click-version: "click>=8,<9"
-            pyyaml-version: "pyyaml>=4,<5"
+            pyyaml-version: "pyyaml>=6,<7"
           - python-version: "3.10"
             pandoc-version: "latest"
             click-version: "click>=6,<7"
-            pyyaml-version: "pyyaml>=5,<6"
+            pyyaml-version: "pyyaml>=3,<4"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,28 +22,37 @@ jobs:
       max-parallel: 5
       matrix:
         # see setup.py for supported versions
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
-        # should test sparingly across API breaking boundaries
-        pandoc-version:
-          # earliest supported pandoc version
-          - 2.11.0.4
-          # - 2.11.1
-          # - 2.11.1.1
-          # - 2.11.2
-          # - 2.11.3
-          # - 2.11.3.1
-          # - 2.11.3.2
-          # - 2.11.4
-          # - 2.12
-          - latest
-        # tests multiple versions of `install_requires` when we want to expand the support matrix
-        click-version:
-          # - 'click>=6,<7'
-          # - 'click>=7,<8'
-          - 'click>=8,<9'
-        pyyaml-version:
-          # - 'pyyaml>=3,<4'
-          - 'pyyaml>=5,<6'
+        # here instead of having a matrix to test against 7 * 7 * 3 * 4 combinations
+        # we only test 7 combinations in a round-robin fashion
+        include:
+          - python-version: 3.6
+            pandoc-version: 2.11.0.4
+            click-version: click>=6,<7
+            pyyaml-version: pyyaml>=3,<4
+          - python-version: pypy-3.6
+            pandoc-version: 2.12
+            click-version: click>=7,<8
+            pyyaml-version: pyyaml>=4,<5
+          - python-version: 3.7
+            pandoc-version: 2.13
+            click-version: click>=8,<9
+            pyyaml-version: pyyaml>=5,<6
+          - python-version: pypy-3.7
+            pandoc-version: 2.14.2
+            click-version: click>=6,<7
+            pyyaml-version: pyyaml>=6,<7
+          - python-version: 3.8
+            pandoc-version: 2.15
+            click-version: click>=7,<8
+            pyyaml-version: pyyaml>=3,<4
+          - python-version: 3.9
+            pandoc-version: 2.16.2
+            click-version: click>=8,<9
+            pyyaml-version: pyyaml>=4,<5
+          - python-version: 3.10
+            pandoc-version: latest
+            click-version: click>=6,<7
+            pyyaml-version: pyyaml>=5,<6
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,6 +24,8 @@ jobs:
         # see setup.py for supported versions
         # here instead of having a matrix to test against 7 * 7 * 3 * 3 combinations
         # we only test 7 combinations in a round-robin fashion
+        # make sure the versions are monotmonic increasing w.r.t. each other
+        # other wise e.g. an older version of a dependency may not work well with a newer version of Python
         include:
           - python-version: "3.6"
             pandoc-version: "2.11.0.4"
@@ -31,28 +33,28 @@ jobs:
             pyyaml-version: "pyyaml>=3,<4"
           - python-version: "pypy-3.6"
             pandoc-version: "2.12"
-            click-version: "click>=7,<8"
-            pyyaml-version: "pyyaml>=5,<6"
-          - python-version: "3.7"
-            pandoc-version: "2.13"
-            click-version: "click>=8,<9"
-            pyyaml-version: "pyyaml>=6,<7"
-          - python-version: "pypy-3.7"
-            pandoc-version: "2.14.2"
             click-version: "click>=6,<7"
             pyyaml-version: "pyyaml>=3,<4"
-          - python-version: "3.8"
-            pandoc-version: "2.15"
+          - python-version: "3.7"
+            pandoc-version: "2.13"
             click-version: "click>=7,<8"
             pyyaml-version: "pyyaml>=5,<6"
+          - python-version: "pypy-3.7"
+            pandoc-version: "2.14.2"
+            click-version: "click>=7,<8"
+            pyyaml-version: "pyyaml>=5,<6"
+          - python-version: "3.8"
+            pandoc-version: "2.15"
+            click-version: "click>=8,<9"
+            pyyaml-version: "pyyaml>=6,<7"
           - python-version: "3.9"
             pandoc-version: "2.16.2"
             click-version: "click>=8,<9"
             pyyaml-version: "pyyaml>=6,<7"
           - python-version: "3.10"
             pandoc-version: "latest"
-            click-version: "click>=6,<7"
-            pyyaml-version: "pyyaml>=3,<4"
+            click-version: "click>=8,<9"
+            pyyaml-version: "pyyaml>=6,<7"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,34 +25,34 @@ jobs:
         # here instead of having a matrix to test against 7 * 7 * 3 * 4 combinations
         # we only test 7 combinations in a round-robin fashion
         include:
-          - python-version: 3.6
-            pandoc-version: 2.11.0.4
-            click-version: click>=6,<7
-            pyyaml-version: pyyaml>=3,<4
-          - python-version: pypy-3.6
-            pandoc-version: 2.12
-            click-version: click>=7,<8
-            pyyaml-version: pyyaml>=4,<5
-          - python-version: 3.7
-            pandoc-version: 2.13
-            click-version: click>=8,<9
-            pyyaml-version: pyyaml>=5,<6
-          - python-version: pypy-3.7
-            pandoc-version: 2.14.2
-            click-version: click>=6,<7
-            pyyaml-version: pyyaml>=6,<7
-          - python-version: 3.8
-            pandoc-version: 2.15
-            click-version: click>=7,<8
-            pyyaml-version: pyyaml>=3,<4
-          - python-version: 3.9
-            pandoc-version: 2.16.2
-            click-version: click>=8,<9
-            pyyaml-version: pyyaml>=4,<5
-          - python-version: 3.10
-            pandoc-version: latest
-            click-version: click>=6,<7
-            pyyaml-version: pyyaml>=5,<6
+          - python-version: "3.6"
+            pandoc-version: "2.11.0.4"
+            click-version: "click>=6,<7"
+            pyyaml-version: "pyyaml>=3,<4"
+          - python-version: "pypy-3.6"
+            pandoc-version: "2.12"
+            click-version: "click>=7,<8"
+            pyyaml-version: "pyyaml>=4,<5"
+          - python-version: "3.7"
+            pandoc-version: "2.13"
+            click-version: "click>=8,<9"
+            pyyaml-version: "pyyaml>=5,<6"
+          - python-version: "pypy-3.7"
+            pandoc-version: "2.14.2"
+            click-version: "click>=6,<7"
+            pyyaml-version: "pyyaml>=6,<7"
+          - python-version: "3.8"
+            pandoc-version: "2.15"
+            click-version: "click>=7,<8"
+            pyyaml-version: "pyyaml>=3,<4"
+          - python-version: "3.9"
+            pandoc-version: "2.16.2"
+            click-version: "click>=8,<9"
+            pyyaml-version: "pyyaml>=4,<5"
+          - python-version: "3.10"
+            pandoc-version: "latest"
+            click-version: "click>=6,<7"
+            pyyaml-version: "pyyaml>=5,<6"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 
 <!-- For pandoc API verion, check https://hackage.haskell.org/package/pandoc for pandoc-types, which is the same thing. -->
 
-| panflute version  | supported pandoc versions | supported pandoc API versions |
-| ---   | ---   |  ---  |
-| 2.1 | 2.11.0.4—2.14.x  | 1.22    |
-| 2.0 | 2.11.0.4—2.11.x  | 1.22    |
-| not supported | 2.10  | 1.21  |
-| 1.12 | 2.7-2.9 | 1.17.5–1.20  |
+| panflute version | supported pandoc versions | supported pandoc API versions |
+| ---------------- | ------------------------- | ----------------------------- |
+| 2.1.3            | 2.11.0.4–2.16.x           | 1.22–1.22.1                   |
+| 2.1              | 2.11.0.4—2.14.x           | 1.22                          |
+| 2.0              | 2.11.0.4—2.11.x           | 1.22                          |
+| not supported    | 2.10                      | 1.21                          |
+| 1.12             | 2.7-2.9                   | 1.17.5–1.20                   |
 
 Note: pandoc 2.10 is short lived and 2.11 has minor API changes comparing to that, mainly for fixing its shortcomings. Please avoid using pandoc 2.10.
 

--- a/panflute/version.py
+++ b/panflute/version.py
@@ -2,4 +2,4 @@
 Panflute version
 """
 
-__version__ = '2.1.2'
+__version__ = '2.1.3'

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'click >=6,<9',
-        'pyyaml >=3,<6',
+        'pyyaml >=3,<7',
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/tests/filters/assert_env.py
+++ b/tests/filters/assert_env.py
@@ -12,7 +12,8 @@ def prepare(doc):
         pf.debug(f'    {k}={v}')
 
     assert doc.pandoc_version >= (2, 11, 0)
-    assert doc.pandoc_reader_options['readerStandalone'] is False
+    standalone_key = 'readerStandalone' if doc.pandoc_version < (2, 16, 0) else "standalone"
+    assert doc.pandoc_reader_options[standalone_key] is False
 
 
 def action(elem, doc):


### PR DESCRIPTION
- fix a test failure related to change in `PANDOC_READER_OPTIONS` with pandoc 2.16+
- support Python 3.10
- allow pyyaml 6: [pyyaml/CHANGES at master · yaml/pyyaml](https://github.com/yaml/pyyaml/blob/master/CHANGES)
- have a more sophisticated GitHub Actions matrix to test all supported versions, using the include syntax: [Workflow syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix)

Notes:

pandoc 2.16 release summary: [Release pandoc 2.16 · jgm/pandoc](https://github.com/jgm/pandoc/releases/tag/2.16)

Running `python tests/test_env.py`,

```markdown
 - Testing Doc() created by panflute:
 - No environment vars; as expected

 - Testing Doc() created by panflute.convert_text():
 - No environment vars; as expected

 - Testing Doc() as created by a filter:
  Pandoc version: (2, 16, 2)
  Pandoc reader options:
    extensions=['all_symbols_escapable', 'auto_identifiers', 'backtick_code_blocks', 'blank_before_blockquote', 'blank_before_header', 'bracketed_spans', 'citations', 'definition_lists', 'escaped_line_breaks', 'example_lists', 'fancy_lists', 'fenced_code_attributes', 'fenced_code_blocks', 'fenced_divs', 'footnotes', 'grid_tables', 'header_attributes', 'implicit_figures', 'implicit_header_references', 'inline_code_attributes', 'inline_notes', 'intraword_underscores', 'latex_macros', 'line_blocks', 'link_attributes', 'markdown_in_html_blocks', 'multiline_tables', 'native_divs', 'native_spans', 'pandoc_title_block', 'pipe_tables', 'raw_attribute', 'raw_html', 'raw_tex', 'shortcut_reference_links', 'simple_tables', 'smart', 'space_in_atx_header', 'startnum', 'strikeout', 'subscript', 'superscript', 'task_lists', 'table_captions', 'tex_math_dollars', 'yaml_metadata_block']
    standalone=False
    columns=72
    tab-stop=4
    indented-code-classes=[]
    abbreviations=['Apr.', 'Aug.', 'Bros.', 'Capt.', 'Co.', 'Corp.', 'Dec.', 'Dr.', 'Feb.', 'Fr.', 'Gen.', 'Gov.', 'Hon.', 'Inc.', 'Jan.', 'Jr.', 'Jul.', 'Jun.', 'Ltd.', 'M.A.', 'M.D.', 'Mar.', 'Mr.', 'Mrs.', 'Ms.', 'No.', 'Nov.', 'Oct.', 'Ph.D.', 'Pres.', 'Prof.', 'Rep.', 'Rev.', 'Sen.', 'Sep.', 'Sept.', 'Sgt.', 'Sr.', 'St.', 'aet.', 'aetat.', 'al.', 'bk.', 'c.', 'cf.', 'ch.', 'chap.', 'chs.', 'col.', 'cp.', 'd.', 'e.g.', 'ed.', 'eds.', 'esp.', 'f.', 'fasc.', 'ff.', 'fig.', 'fl.', 'fol.', 'fols.', 'i.e.', 'ill.', 'incl.', 'n.', 'n.b.', 'nn.', 'p.', 'pp.', 'pt.', 'q.v.', 's.v.', 's.vv.', 'saec.', 'sec.', 'univ.', 'viz.', 'vol.', 'vs.']
    default-image-extension=
    track-changes=accept-changes
    strip-comments=False

 - Found environment vars; as expected
```

Comparing to that of pandoc 2.15:

```markdown
 - Testing Doc() created by panflute:
 - No environment vars; as expected

 - Testing Doc() created by panflute.convert_text():
 - No environment vars; as expected

 - Testing Doc() as created by a filter:
  Pandoc version: (2, 15)
  Pandoc reader options:
    readerExtensions=2559145596334764125609794
    readerStandalone=False
    readerColumns=72
    readerTabStop=4
    readerIndentedCodeClasses=[]
    readerAbbreviations=['Apr.', 'Aug.', 'Bros.', 'Capt.', 'Co.', 'Corp.', 'Dec.', 'Dr.', 'Feb.', 'Fr.', 'Gen.', 'Gov.', 'Hon.', 'Inc.', 'Jan.', 'Jr.', 'Jul.', 'Jun.', 'Ltd.', 'M.A.', 'M.D.', 'Mar.', 'Mr.', 'Mrs.', 'Ms.', 'No.', 'Nov.', 'Oct.', 'Ph.D.', 'Pres.', 'Prof.', 'Rep.', 'Rev.', 'Sen.', 'Sep.', 'Sept.', 'Sgt.', 'Sr.', 'St.', 'aet.', 'aetat.', 'al.', 'bk.', 'c.', 'cf.', 'ch.', 'chap.', 'chs.', 'col.', 'cp.', 'd.', 'e.g.', 'ed.', 'eds.', 'esp.', 'f.', 'fasc.', 'ff.', 'fig.', 'fl.', 'fol.', 'fols.', 'i.e.', 'ill.', 'incl.', 'n.', 'n.b.', 'nn.', 'p.', 'pp.', 'pt.', 'q.v.', 's.v.', 's.vv.', 'saec.', 'sec.', 'univ.', 'viz.', 'vol.', 'vs.']
    readerDefaultImageExtension=
    readerTrackChanges=accept-changes
    readerStripComments=False

 - Found environment vars; as expected
```

Most of the keys are changed, and the contents are more useful as is.