### PR TITLE
Optionally ordered yaml

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,6 +55,7 @@ jobs:
             pandoc-version: "latest"
             click-version: "click>=8,<9"
             pyyaml-version: "pyyaml>=6,<7"
+            yamlloader-version: "yamlloader>=1,<2"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -66,6 +67,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install "${{ matrix.click-version }}" "${{ matrix.pyyaml-version }}"
         python -m pip install ".[dev]"
+    - name: Install yamlloader
+      if: ${{ matrix.yamlloader-version }}
+      run: python -m pip install "${{ matrix.yamlloader-version }}"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Edit: note that panflute only calls pyyaml when using `yaml_filter` (yaml in code block) so this only changes the order of reading the YAML metadata inside that code block. Ordering is nice when round-trip is needed, i.e. a filter convert from yaml code block, and another filter convert it back.

by using yamlloader whenever available.

See doc in https://github.com/Phynix/yamlloader

>an OrderedDict loader/dumper is implemented, allowing to keep items order when loading resp. dumping a file from/to an OrderedDict (Python 3.7+: Also regular dicts are supported and are the default items to be loaded to. As of Python 3.7 preservation of insertion order is a language feature of regular dicts.)

Note: while yamlloader is not very popular, I've been using it in all of my projects (including some that depends on panflute) for a few years and it never has causes any problems.

Also see #178. Had we move to ruamel.yaml, the ordering comes for free. But I think it is better to stick with pyyaml (with yaml spec 1.1) as pandoc is reverting to yaml spec 1.1 as well.

Edit: also the reason to not use oyaml despite they said it is a drop in replacement of pyyaml with ordered dict, oyaml is not released as frequently as the upstream (pyyaml). The yamlloader model is better, that it decouples from pyyaml and releases only the Loaders/Dumpers, so the upstream can be updated independent of yamlloader.