### PR TITLE
Minor fixes and improvements

### DIFF
--- a/panflute/autofilter.py
+++ b/panflute/autofilter.py
@@ -144,13 +144,13 @@ help_str = """Allows Panflute to be run as a command line executable:
 
 * to be used in Pandoctools shell scripts as Pandoc filter with
 multiple arguments (should have -t/--to option in this case):
-`pandoc -t json | panfl -t markdown foo.bar | pandoc -f json`
+`pandoc example.md -t json | panfl foo.bar -t markdown | pandoc -f json`
 
 * to be used as a Pandoc filter (in this case only one positional
 argument is allowed of all options): `pandoc --filter panfl`
 
 Filters may be set with or without .py extension.
-It can be relative or absolutele paths to files or modules specs
+It can be relative or absolute paths to files or modules specs
 like `foo.bar`.
 
 MIND THAT Panflute temporarily prepends folder of the filter

--- a/panflute/io.py
+++ b/panflute/io.py
@@ -152,6 +152,7 @@ def run_filters(actions,
                 prepare=None, finalize=None,
                 input_stream=None, output_stream=None,
                 doc=None,
+                walk_inlines=True,
                 **kwargs):
     r"""
     Receive a Pandoc document from the input stream (default is stdin),
@@ -202,7 +203,7 @@ def run_filters(actions,
     for action in actions:
         if kwargs:
             action = partial(action, **kwargs)
-        doc = doc.walk(action, doc)
+        doc = doc.walk(action, doc=doc, walk_inlines=walk_inlines)
 
     if finalize is not None:
         finalize(doc)

--- a/panflute/tools.py
+++ b/panflute/tools.py
@@ -340,7 +340,10 @@ def shell(args, wait=True, msg=None):
         out, err = proc.communicate(input=msg)
         exitcode = proc.returncode
         if exitcode != 0:
-            raise IOError(err)
+            debug('<<<< shell call failed; error message below >>>>')
+            debug(err.decode('utf-8'))
+            debug('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>')
+            raise IOError()
         return out
     else:
         DETACHED_PROCESS = 0x00000008

--- a/panflute/version.py
+++ b/panflute/version.py
@@ -2,4 +2,4 @@
 Panflute version
 """
 
-__version__ = '2.1.3'
+__version__ = '2.1.4'


### PR DESCRIPTION
- `walk()` method now accepts a `walk_inlines=True` argument. If set to False, panflute will only walk through the block elements and not through the deeper inline elements, so the filter runs much faster.
- This change is also propagated to the `run_filter()` and run_filters()` functions.
- Fixed typos in documentation and tweaked an error message.