### PR TITLE
Fix invalid escape sequence in panflute/io.py

### DIFF
--- a/panflute/io.py
+++ b/panflute/io.py
@@ -140,7 +140,7 @@ def toJSONFilter(*args, **kwargs):
     """
     Wrapper for :func:`.run_filter`, which calls :func:`.run_filters`
 
-    toJSONFilter(action, prepare=None, finalize=None, input_stream=None, output_stream=None, \*\*kwargs)
+    toJSONFilter(action, prepare=None, finalize=None, input_stream=None, output_stream=None, **kwargs)
     Receive a Pandoc document from stdin, apply the *action* function to each element, and write it back to stdout.
 
     See also :func:`.toJSONFilters`


### PR DESCRIPTION
Ran pytest today and got the following warning:
```
panflute/panflute/io.py:140: DeprecationWarning: invalid escape sequence '\*'
```
This PR removes the offending `\*`s.

I hope to contribute something more substantial this weekend, I'm thinking of writing the use_pandoc option for stringify()