### PR TITLE
Allow Table class to have no caption

### DIFF
--- a/panflute/table_elements.py
+++ b/panflute/table_elements.py
@@ -135,9 +135,10 @@ class Table(Block):
 
     @caption.setter
     def caption(self, value):
-        self._caption = check_type(value, Caption)
-        self._caption.parent = self
-        self._caption.location = 'caption'
+        self._caption = check_type_or_value(value, Caption, None)
+        if self._caption is not None:
+            self._caption.parent = self
+            self._caption.location = 'caption'
 
     def _slots_to_json(self):
         ica = self._ica_to_json()


### PR DESCRIPTION
The Table class `__init__` function defaults to setting the caption parameter to `None`:

https://github.com/sergiocorreia/panflute/blob/354297b90b763f99dee270b9e180baa21187cd64/panflute/table_elements.py#L69-L70

However, creating a Table with `caption=None` currently throws an error. This PR allows for the caption parameter to equal `None`.

I would be happy to write a test for this if you feel it would be appropriate.

Addresses #209, and possibly #206.