### PR TITLE
Fix install from github URL

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -10,7 +10,7 @@ To install panflute from PyPI, open the command line and type::
 
 To install the latest Github version of panflute, type::
 
-    pip install git+git://github.com/sergiocorreia/panflute.git
+    pip install git+https://github.com/sergiocorreia/panflute.git
 
 
 Dev Install


### PR DESCRIPTION
I don't think git+git is a valid protocol. Either way, it didn't work for me, and the more common git+https did!