### PR TITLE
Added fix for unstable element index (issue #223)

### DIFF
--- a/panflute/base.py
+++ b/panflute/base.py
@@ -22,7 +22,7 @@ class Element(object):
     """
     Base class of all Pandoc elements
     """
-    __slots__ = ['parent', 'location']
+    __slots__ = ['parent', 'location', 'index']
     _children = []
 
     def __new__(cls, *args, **kwargs):
@@ -30,6 +30,7 @@ class Element(object):
         element = object.__new__(cls)
         element.parent = None
         element.location = None
+        element.index = None
         return element
 
     @property
@@ -133,17 +134,6 @@ class Element(object):
     # ---------------------------
     # Navigation
     # ---------------------------
-
-    @property
-    def index(self):
-        """
-        Return position of element inside the parent.
-
-        :rtype: ``int`` | ``None``
-        """
-        container = self.container
-        if container is not None:
-            return container.index(self)
 
     @property
     def container(self):

--- a/panflute/containers.py
+++ b/panflute/containers.py
@@ -18,7 +18,8 @@ from .utils import check_type, encode_dict, debug
 # These are list and dict containers that
 #  (a) track the identity of their parents, and
 #  (b) track the parent's property where they are stored
-# They attach these two to the elements requested through __getattr__
+#  (c) track the index in the parent in case of list
+# They attach these three to the elements requested through __getattr__
 
 class ListContainer(MutableSequence):
     """
@@ -55,7 +56,7 @@ class ListContainer(MutableSequence):
 
     def __getitem__(self, i):
         if isinstance(i, int):
-            return attach(self.list[i], self.parent, self.location)
+            return attach(self.list[i], self.parent, self.location, i)
         else:
             newlist = self.list.__getitem__(i)
             obj = ListContainer(*newlist,
@@ -168,10 +169,11 @@ class DictContainer(MutableMapping):
 # Functions
 # ---------------------------
 
-def attach(element, parent, location):
+def attach(element, parent, location, index=None):
     if not isinstance(element, (int, str, bool)):
         element.parent = parent
         element.location = location
+        element.index = index
     else:
         debug(f'Warning: element "{type(element)}" has no parent')
     return element

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -11,5 +11,20 @@ def test_quotes_129():
     assert output == '"Some quoted text"'
 
 
+def test_index_223():
+    """Index values on duplicated elements are determined using list.index()
+    but this returns the index first found element.
+    This test checks whether the index on the element corresponds with the
+    actual index in the parent collection.
+    """
+    # pf https://github.com/sergiocorreia/panflute/issues/223
+    doc = pf.Doc(pf.Para(pf.Str("a")), pf.Para(pf.Str("b")),
+                 pf.Para(pf.Str("a")), pf.Para(pf.Str("c")))
+
+    for (index, element) in enumerate(doc.content):
+        assert element.index == index
+
+
 if __name__ == "__main__":
     test_quotes_129()
+    test_index_223()


### PR DESCRIPTION
Hi, I solved the issue described in #223 using this patch locally. With this adaption I was able to run my filter as expected.
Also added a smaller test than in the ticket.

Idea is to fill the index position in the ListContainer along with the parent and location instead of deriving it.
Like this __eq__ on element can be left untouched.