### PR TITLE
Document pandoc 2.19 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ pandoc versioning semantics is [MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org
 
 | panflute version | supported pandoc versions | supported pandoc API versions |
 | ---------------- | ------------------------- | ----------------------------- |
-| 2.1.3            | 2.11.0.4–2.17.x           | 1.22–1.22.1                   |
+| 2.2              | 2.11.0.4-2.19.x           | 1.22                          |
+| 2.1.3            | 2.11.0.4–2.19.x           | 1.22                          |
 | 2.1              | 2.11.0.4—2.14.x           | 1.22                          |
 | 2.0              | 2.11.0.4—2.11.x           | 1.22                          |
 | not supported    | 2.10                      | 1.21                          |


### PR DESCRIPTION
The README file lacks recent panflute/pandoc versions.

CI tests run on pandoc:latest so I guess it is okay to say pandoc 2.19.x is supported?

There has not been many changes in pandoc-types. There is this one that I'm not sure about the implications for panflute compatibility : https://github.com/jgm/pandoc-types/commit/b084b2af7151d2d9ae84b7f558f2a77c5103cdd7