### PR TITLE
fix: Remove broken `test_get_filter_dirs` test

### DIFF
--- a/tests/test_panfl.py
+++ b/tests/test_panfl.py
@@ -37,10 +37,6 @@ os.chdir(str(Path(__file__).parents[1]))
 # Tests
 # ---------------------------
 
-def test_get_filter_dirs():
-    assert sorted(pf.get_filter_dirs()) == sorted(pf.get_filter_dirs(hardcoded=False))
-
-
 def test_metadata():
     """
     panfl can receive filter lists either as a metadata argument or in the YAML block


### PR DESCRIPTION
The test depends on the contents of the user's home directory and is therefore considered broken. The test causes issues for end-users, e.g. when they build the python-panflute AUR package on Arch Linux.

The problem can be reproduced using the following steps:

    $ file ~/.pandoc ~/.local/share/pandoc
    /home/user/.pandoc:             cannot open `/home/user/.pandoc' (No such file or directory)
    /home/user/.local/share/pandoc: cannot open `/home/user/.local/share/pandoc' (No such file or directory)

    $ pytest -k get_filter_dirs
    ======================================================== test session starts =========================================================
    platform linux -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
    rootdir: /home/user/Projects/panflute
    collected 37 items / 36 deselected / 1 selected
    tests/test_panfl.py .                                                                                                          [100%]
    ================================================== 1 passed, 36 deselected in 0.73s ==================================================

    $ mkdir ~/.pandoc

    $ pytest -k get_filter_dirs
    ======================================================== test session starts =========================================================
    platform linux -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
    rootdir: /home/user/Projects/panflute
    collected 37 items / 36 deselected / 1 selected
    tests/test_panfl.py F                                                                                                          [100%]
    ============================================================== FAILURES ==============================================================
    ________________________________________________________ test_get_filter_dirs ________________________________________________________
        def test_get_filter_dirs():
    >       assert sorted(pf.get_filter_dirs()) == sorted(pf.get_filter_dirs(hardcoded=False))
    E       AssertionError: assert ['/home/user/....ndoc/filters'] == ['/home/user/.pandoc/filters']
    E
    E         At index 0 diff: '/home/user/.local/share/pandoc/filters' != '/home/user/.pandoc/filters'
    E         Use -v to get more diff
    tests/test_panfl.py:41: AssertionError
    ====================================================== short test summary info =======================================================
    FAILED tests/test_panfl.py::test_get_filter_dirs - AssertionError: assert ['/home/user/....ndoc/filters'] == ['/home/user/.pandoc/filters']
    ================================================== 1 failed, 36 deselected in 0.77s ==================================================