### PR TITLE
Add latex-merge as RawBlock format

### DIFF
--- a/panflute/elements.py
+++ b/panflute/elements.py
@@ -1248,6 +1248,7 @@ MATH_FORMATS = {'DisplayMath', 'InlineMath'}
 
 RAW_FORMATS = {'tex',
                'latex',
+               'latex-merge',  # From Quarto output.
                'html',
                'context',
                'rtf',


### PR DESCRIPTION
Quarto generates latex-merge as a RawBlock format.

Accept this as a RawBlock format.

Specifically Quarto filters generate this JSON from Markdown `![An
image](some_image.jpg)`:

```
                    {
                        "c": [
                            "latex-merge",
                            "\\begin{figure}[H]"
                        ],
                        "t": "RawBlock"
                    },
```

Without this patch, initial parsing of the JSON input for any Panflute
filter will fail with:

```
TypeError: element str not in group {'native', 'context', 'docbook',
'man', 'twiki', 'dokuwiki', 'rtf', 'tex', 'markdown', 'vimwiki', 'rst',
'creole', 'opml', 'haddock', 'docx', 'epub', 'icml', 'markdown_mmd',
'markdown_strict', 'org', 't2t', 'mediawiki', 'opendocument', 'json',
'muse', 'openxml', 'commonmark', 'gfm', 'html', 'fb2', 'noteref',
'textile', 'markdown_github', 'ipynb', 'markdown_phpextra', 'latex',
'odt', 'tikiwiki', 'jats', 'typst'}
```